### PR TITLE
Add more guarantees to debounced ajax epics

### DIFF
--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -25,6 +25,9 @@ export default function Spinner(props) {
     className += ` ${props.size}`;
   }
   return (
-    <span aria-label="In progess" className={className} />
+    <>
+      <span className={className} />
+      <span className="sr-only">In progress</span>
+    </>
   );
 }

--- a/src/epics/ajax.js
+++ b/src/epics/ajax.js
@@ -1,5 +1,5 @@
-import { filter, groupBy, flatMap, debounceTime } from 'rxjs/operators';
-import { switchAjax, flatAjax } from './custom-operators'
+import { filter, groupBy, flatMap } from 'rxjs/operators';
+import { switchAjax, flatAjax, debounceAjax } from './custom-operators'
 
 export function ajaxEpic(type, operation) {
   return action$ =>
@@ -31,8 +31,7 @@ export function debouncedAjaxEpic(type, operation, debounceMs=400) {
       groupBy(a => a.meta && a.meta.group || 'none'),
       flatMap(groupedAction$ =>
         groupedAction$.pipe(
-          debounceTime(debounceMs),
-          switchAjax(operation)
+          debounceAjax(operation, debounceMs)
         )
       )
     );

--- a/src/epics/custom-operators.js
+++ b/src/epics/custom-operators.js
@@ -1,5 +1,5 @@
 import { Observable, from, of, empty, asyncScheduler } from 'rxjs';
-import { flatMap, switchMap, pluck, map, catchError, throttleTime } from 'rxjs/operators';
+import { flatMap, switchMap, pluck, map, catchError, throttleTime, takeUntil, debounceTime } from 'rxjs/operators';
 import _ from 'lodash';
 
 export { ofType } from 'redux-observable';
@@ -14,15 +14,26 @@ export function pluckPayload(...keys) {
 
 export function createAjaxOperators(options = { errorSuffix: 'ERROR' }) {
   function flatAjax(apiOperation) {
-    return flatMap(createApiOperationMapper(apiOperation));
+    return flatMap(makeAjaxObservableFactory(apiOperation));
   }
 
   function switchAjax(apiOperation) {
-    return switchMap(createApiOperationMapper(apiOperation));
+    return switchMap(makeAjaxObservableFactory(apiOperation));
   }
 
-  function createApiOperationMapper(apiOperation) {
-    return action => {
+  function debounceAjax(apiOperation, debounceMs=400) {
+    const createAjaxObservable = makeAjaxObservableFactory(apiOperation);
+    return observable =>
+      observable.pipe(
+        debounceTime(debounceMs),
+        switchMap(action =>
+          createAjaxObservable(action).pipe(takeUntil(observable))
+        )
+      );
+  }
+
+  function makeAjaxObservableFactory(apiOperation) {
+    return function createAjaxObservable(action) {
       const fsa = isFSA(action);
       const payload = fsa ? action.payload : action;
       const meta = { args: payload };
@@ -73,11 +84,12 @@ export function createAjaxOperators(options = { errorSuffix: 'ERROR' }) {
 
   return {
     flatAjax,
-    switchAjax
+    switchAjax,
+    debounceAjax,
   }
 }
 
-export const { flatAjax, switchAjax } = createAjaxOperators();
+export const { flatAjax, switchAjax, debounceAjax } = createAjaxOperators();
 
 // Flux Standard Action (FSA) check
 function isFSA(data) {

--- a/src/epics/custom-operators.js
+++ b/src/epics/custom-operators.js
@@ -26,15 +26,15 @@ export function createAjaxOperators(options = { errorSuffix: 'ERROR' }) {
     return observable =>
       observable.pipe(
         debounceTime(debounceMs),
-        switchMap(action =>
+        switchMap(action => {
           /*
             We want to immediately cancel the ajax that is in progress
             when another event comes into play, because if we don't, there is
             a chance that we will still be debouncing (which takes "debounceMs"
             before hitting this "switchMap") when the ajax response comes back.
            */
-          createAjaxObservable(action).pipe(takeUntil(observable))
-        )
+          return createAjaxObservable(action).pipe(takeUntil(observable));
+        })
       );
   }
 

--- a/src/epics/custom-operators.js
+++ b/src/epics/custom-operators.js
@@ -27,6 +27,12 @@ export function createAjaxOperators(options = { errorSuffix: 'ERROR' }) {
       observable.pipe(
         debounceTime(debounceMs),
         switchMap(action =>
+          /*
+            We want to immediately cancel the ajax that is in progress
+            when another event comes into play, because if we don't, there is
+            a chance that we will still be debouncing (which takes "debounceMs"
+            before hitting this "switchMap") when the ajax response comes back.
+           */
           createAjaxObservable(action).pipe(takeUntil(observable))
         )
       );


### PR DESCRIPTION
Immediately cancel the ajax that is in progress when another event comes into play, because if we don't, there is a chance that we will still be debouncing when the ajax response comes back.