### PR TITLE
BAP-8002 Allow for not showing datepicker side by side

### DIFF
--- a/src/components/DateRange.js
+++ b/src/components/DateRange.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import Moment from 'moment';
-import { formatDateTime, formatDate } from '../utils/date-utils';
-import { openAtDate } from './InputDatePicker';
+import React from "react";
+import PropTypes from "prop-types";
+import Moment from "moment";
+import { formatDateTime, formatDate } from "../utils/date-utils";
+import { openAtDate } from "./InputDatePicker";
 
 export default class DateRange extends React.Component {
   static propTypes = {
@@ -16,12 +16,13 @@ export default class DateRange extends React.Component {
     defaultDays: PropTypes.number,
     monthLimit: PropTypes.number,
     showTimePicker: PropTypes.bool,
+    sideBySide: PropTypes.bool,
   };
 
   static defaultProps = {
     defaultDays: 0,
-    startDateName: 'startDate',
-    endDateName: 'endDate',
+    startDateName: "startDate",
+    endDateName: "endDate",
   };
 
   state = {
@@ -33,8 +34,12 @@ export default class DateRange extends React.Component {
     return this.props.showTimePicker ? formatDateTime(date) : formatDate(date);
   }
 
-  setStartDateInputRef = input => { this.startDateInput = input; };
-  setEndDateInputRef = input => { this.endDateInput = input; };
+  setStartDateInputRef = (input) => {
+    this.startDateInput = input;
+  };
+  setEndDateInputRef = (input) => {
+    this.endDateInput = input;
+  };
 
   initWithStartDate(startDate) {
     // Open end date picker up at the same place as this start date
@@ -50,10 +55,15 @@ export default class DateRange extends React.Component {
     this.props.onChange({ [this.props.endDateName]: endDate }, true);
   }
 
-  handleDateRangeChange = newState => {
-    const { startDateName, endDateName, defaultDays, monthLimit, minDate } = this.props;
-    let startDate = newState[startDateName] || this.props.startDate || this.state.initStartDate;
-    let endDate = newState[endDateName] || this.props.endDate || this.state.initEndDate;
+  handleDateRangeChange = (newState) => {
+    const { startDateName, endDateName, defaultDays, monthLimit, minDate } =
+      this.props;
+    let startDate =
+      newState[startDateName] ||
+      this.props.startDate ||
+      this.state.initStartDate;
+    let endDate =
+      newState[endDateName] || this.props.endDate || this.state.initEndDate;
 
     if (!endDate) {
       // Busy initialising from blank range, we have only picked a start date at this point
@@ -73,19 +83,19 @@ export default class DateRange extends React.Component {
 
     if (startChanged) {
       if (start.isAfter(end)) {
-        end = Moment(start).add(defaultDays, 'days');
+        end = Moment(start).add(defaultDays, "days");
       }
       if (monthLimit) {
-        end = Moment.min(end, Moment(start).add(monthLimit, 'months')); // Limited to a window
+        end = Moment.min(end, Moment(start).add(monthLimit, "months")); // Limited to a window
       }
     }
 
     if (!startChanged) {
       if (end.isBefore(start)) {
-        start = Moment(end).subtract(defaultDays, 'days');
+        start = Moment(end).subtract(defaultDays, "days");
       }
       if (monthLimit) {
-        start = Moment.max(start, Moment(end).subtract(monthLimit, 'months')); // Limited to a window
+        start = Moment.max(start, Moment(end).subtract(monthLimit, "months")); // Limited to a window
       }
       if (minDate) {
         start = Moment.max(start, Moment(minDate));
@@ -94,7 +104,7 @@ export default class DateRange extends React.Component {
 
     this.props.onChange({
       [startDateName]: this.format(start),
-      [endDateName]: this.format(end)
+      [endDateName]: this.format(end),
     });
 
     // We no longer need this temporary state
@@ -104,22 +114,25 @@ export default class DateRange extends React.Component {
   };
 
   render() {
-    return this.props.children({
+    return this.props.children(
+      {
         onChange: this.handleDateRangeChange,
         value: this.props.startDate,
         name: this.props.startDateName,
         minValue: this.props.minDate,
         inputRef: this.setStartDateInputRef,
         showTimePicker: this.props.showTimePicker,
-      }, {
+        sideBySide: this.props.sideBySide,
+      },
+      {
         onChange: this.handleDateRangeChange,
         value: this.props.endDate,
         name: this.props.endDateName,
         minValue: this.props.minDate,
         inputRef: this.setEndDateInputRef,
         showTimePicker: this.props.showTimePicker,
+        sideBySide: this.props.sideBySide,
       }
     );
   }
 }
-

--- a/src/components/DateTimeInput.js
+++ b/src/components/DateTimeInput.js
@@ -1,7 +1,7 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import Inputable from './Inputable';
-import InputDatePicker from './InputDatePicker';
+import PropTypes from "prop-types";
+import React from "react";
+import Inputable from "./Inputable";
+import InputDatePicker from "./InputDatePicker";
 
 const propTypes = {
   id: PropTypes.string,
@@ -10,10 +10,7 @@ const propTypes = {
   minValue: PropTypes.string,
   maxValue: PropTypes.string,
   name: PropTypes.string,
-  label: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.element,
-  ]),
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   showMessage: PropTypes.bool,
   message: PropTypes.string,
   style: PropTypes.object,
@@ -21,17 +18,27 @@ const propTypes = {
   disabled: PropTypes.bool,
 
   showTimePicker: PropTypes.bool,
+  sideBySide: PropTypes.bool,
   viewMode: PropTypes.string,
   clearable: PropTypes.bool,
-  onClear: PropTypes.func
+  onClear: PropTypes.func,
 };
 
 const defaultProps = {
-  value: ''
+  value: "",
 };
 
-let DateTimeInput = ({ onChange, value, minValue, maxValue, name, clearable, onClear, ...rest }) => (
-  <div className={`input-date-picker ${clearable ? 'input-group' : ''}`}>
+let DateTimeInput = ({
+  onChange,
+  value,
+  minValue,
+  maxValue,
+  name,
+  clearable,
+  onClear,
+  ...rest
+}) => (
+  <div className={`input-date-picker ${clearable ? "input-group" : ""}`}>
     <InputDatePicker
       identifier={name}
       startDate={value}
@@ -40,13 +47,13 @@ let DateTimeInput = ({ onChange, value, minValue, maxValue, name, clearable, onC
       onApply={onChange}
       {...rest}
     />
-    {clearable &&
+    {clearable && (
       <span className="input-group-btn">
         <button type="button" className="btn btn-default" onClick={onClear}>
           <span className="glyphicon glyphicon-remove"></span>
         </button>
       </span>
-    }
+    )}
   </div>
 );
 
@@ -54,4 +61,3 @@ DateTimeInput = Inputable(DateTimeInput);
 DateTimeInput.propTypes = propTypes;
 DateTimeInput.defaultProps = defaultProps;
 export default DateTimeInput;
-

--- a/src/components/InputDatePicker.js
+++ b/src/components/InputDatePicker.js
@@ -54,8 +54,8 @@ export default class InputDatePicker extends React.Component {
       defaultDate: startDate,
       useCurrent: false, // If we have no initial value, we keep the input blank
       keyBinds: null,
-      sideBySide: sideBySide,
-      viewMode: viewMode,
+      sideBySide,
+      viewMode,
     });
 
     if (minDate) {

--- a/src/components/InputDatePicker.js
+++ b/src/components/InputDatePicker.js
@@ -1,10 +1,10 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import _ from 'lodash';
-import Moment from 'moment';
-import { YEAR_MONTH_DAY_TIME, YEAR_MONTH_DAY } from '../utils/date-utils';
-import $ from 'jquery';
-import '../libs/bootstrap-datetimepicker.min';
+import PropTypes from "prop-types";
+import React from "react";
+import _ from "lodash";
+import Moment from "moment";
+import { YEAR_MONTH_DAY_TIME, YEAR_MONTH_DAY } from "../utils/date-utils";
+import $ from "jquery";
+import "../libs/bootstrap-datetimepicker.min";
 
 const propTypes = {
   id: PropTypes.string,
@@ -16,60 +16,73 @@ const propTypes = {
   identifier: PropTypes.string,
   showTimePicker: PropTypes.bool,
   viewMode: PropTypes.string,
+  sideBySide: PropTypes.bool,
   disabled: PropTypes.bool,
-  daysOfWeekDisabled: PropTypes.array
+  daysOfWeekDisabled: PropTypes.array,
 };
 
 const defaultProps = {
-  startDate: '',
-  className: 'datepicker--input',
-  viewMode: 'days',
+  startDate: "",
+  className: "datepicker--input",
+  viewMode: "days",
+  sideBySide: true,
 };
 
 export function openAtDate(input, date) {
-  setProperty($(input), 'viewDate', date);
+  setProperty($(input), "viewDate", date);
   input.focus();
 }
 
 function setProperty($picker, property, value) {
-  return $picker.data('DateTimePicker')[property](value);
+  return $picker.data("DateTimePicker")[property](value);
 }
 
 export default class InputDatePicker extends React.Component {
   componentDidMount() {
-    const { showTimePicker, startDate, viewMode, minDate, maxDate, daysOfWeekDisabled } = this.props;
+    const {
+      showTimePicker,
+      startDate,
+      viewMode,
+      sideBySide,
+      minDate,
+      maxDate,
+      daysOfWeekDisabled,
+    } = this.props;
     const format = showTimePicker ? YEAR_MONTH_DAY_TIME : YEAR_MONTH_DAY;
     const $picker = $(this.picker).datetimepicker({
       format,
       defaultDate: startDate,
       useCurrent: false, // If we have no initial value, we keep the input blank
       keyBinds: null,
-      sideBySide: true,
+      sideBySide: sideBySide,
       viewMode: viewMode,
     });
 
     if (minDate) {
-      setProperty($picker, 'minDate', minDate);
+      setProperty($picker, "minDate", minDate);
     }
 
     if (maxDate) {
-      setProperty($picker, 'maxDate', maxDate);
+      setProperty($picker, "maxDate", maxDate);
     }
 
     if (daysOfWeekDisabled) {
-      setProperty($picker, 'daysOfWeekDisabled', daysOfWeekDisabled);
+      setProperty($picker, "daysOfWeekDisabled", daysOfWeekDisabled);
     }
 
     // Only apply date when we hide the picker
-    $picker.on('dp.hide', () => {
+    $picker.on("dp.hide", () => {
       if (_.isEmpty($picker.val())) {
         // Revert back if we have a date set
         if (this.props.startDate) {
-          setProperty($picker, 'date', this.props.startDate);
+          setProperty($picker, "date", this.props.startDate);
         } else {
           // Blank state UX: Hack to open up the picker at the same place it was last closed
-          const currentViewDate = $picker.data('DateTimePicker').viewDate();
-          setTimeout(() => setProperty($picker, 'viewDate', currentViewDate), 0);
+          const currentViewDate = $picker.data("DateTimePicker").viewDate();
+          setTimeout(
+            () => setProperty($picker, "viewDate", currentViewDate),
+            0
+          );
         }
         return;
       }
@@ -80,14 +93,14 @@ export default class InputDatePicker extends React.Component {
     });
 
     // Key bindings are turned off, so we can determine our custom behaviour
-    $picker.on('keyup', (e) => {
+    $picker.on("keyup", (e) => {
       // Do nothing if arrow keys are being used
       if (e.which >= 37 && e.which <= 40) {
         return;
       }
       // Set date and hide picker on enter
       if (e.which === 13) {
-        const dropDown = $picker.data('DateTimePicker');
+        const dropDown = $picker.data("DateTimePicker");
         dropDown.date($picker.val());
         dropDown.hide();
         // If the date is strictly valid as we type, then set date and keep cursor position
@@ -95,7 +108,7 @@ export default class InputDatePicker extends React.Component {
         const start = $picker[0].selectionStart;
         const end = $picker[0].selectionEnd;
 
-        setProperty($picker, 'date', $picker.val());
+        setProperty($picker, "date", $picker.val());
         $picker[0].setSelectionRange(start, end);
         this.props.onApply($picker.val());
       }
@@ -105,24 +118,24 @@ export default class InputDatePicker extends React.Component {
   componentDidUpdate(prevProps) {
     const $picker = $(this.picker);
     if (prevProps.minDate !== this.props.minDate) {
-      setProperty($picker, 'minDate', this.props.minDate);
+      setProperty($picker, "minDate", this.props.minDate);
     }
     if (prevProps.maxDate !== this.props.maxDate) {
-      setProperty($picker, 'maxDate', this.props.maxDate);
+      setProperty($picker, "maxDate", this.props.maxDate);
     }
     // Apply the new date last as the min/max date could have changed as well
     if (prevProps.startDate !== this.props.startDate) {
       if ($picker.val() !== this.props.startDate) {
-        setProperty($picker, 'date', this.props.startDate || null);
+        setProperty($picker, "date", this.props.startDate || null);
       }
     }
   }
 
   componentWillUnmount() {
-    $(this.picker).data('DateTimePicker').destroy();
+    $(this.picker).data("DateTimePicker").destroy();
   }
 
-  handleRef = ref => {
+  handleRef = (ref) => {
     this.picker = ref;
     const { inputRef } = this.props;
     if (inputRef) {
@@ -137,11 +150,13 @@ export default class InputDatePicker extends React.Component {
       <span className="date-time-input-container">
         <input
           id={this.props.id}
-          aria-label={this.props['aria-label']}
-          aria-describedby={this.props['aria-describedby']}
-          aria-errormessage={this.props['aria-errormessage']}
-          aria-invalid={this.props['aria-invalid']}
-          data-identifier={this.props['data-identifier'] || this.props.dataIdentifier}
+          aria-label={this.props["aria-label"]}
+          aria-describedby={this.props["aria-describedby"]}
+          aria-errormessage={this.props["aria-errormessage"]}
+          aria-invalid={this.props["aria-invalid"]}
+          data-identifier={
+            this.props["data-identifier"] || this.props.dataIdentifier
+          }
           ref={this.handleRef}
           type="text"
           className="form-control"
@@ -151,11 +166,12 @@ export default class InputDatePicker extends React.Component {
           placeholder={this.props.placeholder}
           autoComplete="off"
         />
+
         <span onClick={this.handleCalendarClick} className="icon-container">
           <span className="icon-calendar" />
         </span>
       </span>
-    )
+    );
   }
 }
 


### PR DESCRIPTION
### Related issue
[Link to issue](https://bazaruto.atlassian.net/browse/BAP-8002)

### Feature Flag (or reason if not used)
Feature flag on bazaruto where this is specifically used is https://www.flippercloud.io/organizations/nawiri/projects/bazaruto/environments/production/features/modal-individual-scroll

### What does this change?
- This allows the sideBySide property on the datetimepicker to be set by the component that uses it. In essense, the time and date can be toggled instead of being side by side. 

### How did you action this task?
1. Added the property
2. Tested the library on my local bazaruto
3. Tidied up the css required for this to work well and flexibly

### What tests were added/updated?
- No tests were added

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have manually tested my changes
- [x] I have taken screenshots of front-end changes
- [x] I have confirmed there are no browser console errors

### Screenshots (if appropriate)
Before: 
![image](https://github.com/user-attachments/assets/25bf6003-7b76-4a72-ba59-b6e7d9cf3084)

After:
![image](https://github.com/user-attachments/assets/8ca77e1a-0bfe-4fd1-8184-f69f06012084)
![image](https://github.com/user-attachments/assets/b2f010a6-ec0c-4bc1-a8f9-2fb4abaad0e5)
